### PR TITLE
refactor the NewTreeTopology to use nTasks instead maxID

### DIFF
--- a/framework_regression_test.go
+++ b/framework_regression_test.go
@@ -232,7 +232,7 @@ func (tc simpleTaskBuilder) GetTask(taskID uint64) Task {
 func drive(t *testing.T, jobName string, etcds []string, config Config, ntask uint64, taskBuilder TaskBuilder) {
 	bootstrap := NewBootStrap(jobName, etcds, config, createListener(t), nil)
 	bootstrap.SetTaskBuilder(taskBuilder)
-	bootstrap.SetTopology(NewTreeTopology(2, ntask-1))
+	bootstrap.SetTopology(NewTreeTopology(2, ntask))
 	bootstrap.Start()
 }
 

--- a/framework_test.go
+++ b/framework_test.go
@@ -60,9 +60,9 @@ func TestFrameworkFlagMetaReady(t *testing.T) {
 		setupLatch: &wg,
 	}
 	f0.SetTaskBuilder(taskBuilder)
-	f0.SetTopology(NewTreeTopology(2, 1))
+	f0.SetTopology(NewTreeTopology(2, 2))
 	f1.SetTaskBuilder(taskBuilder)
-	f1.SetTopology(NewTreeTopology(2, 1))
+	f1.SetTopology(NewTreeTopology(2, 2))
 
 	taskBuilder.setupLatch.Add(1)
 	go f0.Start()
@@ -160,13 +160,13 @@ func TestFrameworkDataRequest(t *testing.T) {
 	}
 	taskBuilder.setupLatch.Add(1)
 	f0.SetTaskBuilder(taskBuilder)
-	f0.SetTopology(NewTreeTopology(2, 1))
+	f0.SetTopology(NewTreeTopology(2, 2))
 	go f0.Start()
 	defer f0.stop()
 	taskBuilder.setupLatch.Wait()
 	taskBuilder.setupLatch.Add(1)
 	f1.SetTaskBuilder(taskBuilder)
-	f1.SetTopology(NewTreeTopology(2, 1))
+	f1.SetTopology(NewTreeTopology(2, 2))
 	go f1.Start()
 	defer f1.stop()
 	taskBuilder.setupLatch.Wait()

--- a/tree_topo.go
+++ b/tree_topo.go
@@ -43,11 +43,11 @@ func (t *TreeTopology) SetNumberOfTasks(nt uint64) {
 }
 
 // Creates a new tree topology with given fanout and number of tasks.
-// This will be called each
-func NewTreeTopology(fanout, maxID uint64) *TreeTopology {
+// This will be called during the task graph configuration.
+func NewTreeTopology(fanout, nTasks uint64) *TreeTopology {
 	m := &TreeTopology{
 		fanout:     fanout,
-		numOfTasks: maxID + 1,
+		numOfTasks: nTasks,
 	}
 	return m
 }

--- a/tree_topo_test.go
+++ b/tree_topo_test.go
@@ -30,7 +30,7 @@ func TestTreeToplogy27(t *testing.T) {
 			[]uint64{2}, []uint64{},
 		},
 	}
-	testTreeTopology(2, 7, tests27, t)
+	testTreeTopology(2, 8, tests27, t)
 }
 
 //     0
@@ -52,7 +52,7 @@ func TestTreeToplogy28(t *testing.T) {
 			[]uint64{1}, []uint64{7, 8},
 		},
 	}
-	testTreeTopology(2, 8, tests28, t)
+	testTreeTopology(2, 9, tests28, t)
 }
 
 func testTreeTopology(fanout, number uint64, tests []treeTopoTest, t *testing.T) {


### PR DESCRIPTION
this way, we can use number of task directly, a more natural way of specify the number of tasks.
