### PR TITLE
util: implement tryOccupyTask

### DIFF
--- a/framework/bootstrap.go
+++ b/framework/bootstrap.go
@@ -130,14 +130,8 @@ func (f *framework) occupyTask() (uint64, error) {
 			f.log.Printf("WARN: taskID isn't integer, registration on etcd has been corrupted!")
 			continue
 		}
-		// Below operations are one atomic behavior:
-		// - See if current task is unassigned.
-		// - If it's unassgined, currently task will set its ip address to the key.
-		_, err = f.etcdClient.CompareAndSwap(
-			etcdutil.MakeTaskMasterPath(f.name, id),
-			f.ln.Addr().String(),
-			0, "empty", 0)
-		if err == nil {
+		ok := etcdutil.TryOccupyTask(f.etcdClient, f.name, id, f.ln.Addr().String())
+		if ok {
 			return id, nil
 		}
 	}

--- a/framework/standby.go
+++ b/framework/standby.go
@@ -5,7 +5,7 @@ import "github.com/go-distributed/meritop/pkg/etcdutil"
 func (f *framework) standby() error {
 	for {
 		failedTask := etcdutil.WaitFailure(f.etcdClient, f.name)
-		ok := etcdutil.TryOccupyTask(f.etcdClient, f.name, failedTask)
+		ok := etcdutil.TryOccupyTask(f.etcdClient, f.name, failedTask, f.ln.Addr().String())
 		if ok {
 			f.taskID = failedTask
 			return nil

--- a/pkg/etcdutil/layout.go
+++ b/pkg/etcdutil/layout.go
@@ -12,6 +12,7 @@ import (
 //   /{app}/tasks/{taskID}/{replicaID} -> pointer to nodes, 0 replicaID means master
 //   /{app}/tasks/{taskID}/parentMeta
 //   /{app}/tasks/{taskID}/childMeta
+//   /{app}/tasks/{taskID}/healthy
 //   /{app}/nodes/: register nodes under this directory
 //   /{app}/nodes/{nodeID}/address -> scheme://host:port/{path(if http)}
 //   /{app}/nodes/{nodeID}/ttl -> keep alive timeout
@@ -27,10 +28,15 @@ const (
 	TaskChildMeta  = "ChildMeta"
 	NodeAddr       = "address"
 	NodeTTL        = "ttl"
+	healthy        = "healthy"
 )
 
 func EpochPath(appName string) string {
 	return path.Join("/", appName, Epoch)
+}
+
+func HealthyPath(appName string, taskID uint64) string {
+	return path.Join("/", appName, TasksDir, strconv.FormatUint(taskID, 10), healthy)
 }
 
 func MakeTaskDirPath(appName string) string {

--- a/pkg/etcdutil/task.go
+++ b/pkg/etcdutil/task.go
@@ -1,7 +1,20 @@
 package etcdutil
 
-import "github.com/coreos/go-etcd/etcd"
+import (
+	"log"
 
-func TryOccupyTask(client *etcd.Client, name string, taskID uint64) bool {
-	return false
+	"github.com/coreos/go-etcd/etcd"
+)
+
+func TryOccupyTask(client *etcd.Client, name string, taskID uint64, connection string) bool {
+	_, err := client.Create(HealthyPath(name, taskID), "health", 30)
+	if err != nil {
+		return false
+	}
+
+	_, err = client.Set(MakeTaskMasterPath(name, taskID), connection, 0)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return true
 }


### PR DESCRIPTION
This PR implements TryOccupyTask:
1. on master failure, standby task will get notified on the `health` key being deleted.
2. one of standby will create successfully a new `health` key and take over the task.
3. the new host should register relevant information at that point as well.
