### PR TITLE
Regression failover test: slave ChildDataReady failure

### DIFF
--- a/framework/bootstrap.go
+++ b/framework/bootstrap.go
@@ -78,7 +78,7 @@ func (f *framework) Start() {
 }
 
 func (f *framework) setupChannels() {
-	f.closedSignal = make(chan struct{})
+	f.httpStop = make(chan struct{})
 	f.metaChan = make(chan *metaChange, 100)
 	f.dataReqtoSendChan = make(chan *dataRequest, 100)
 	f.dataReqChan = make(chan *dataRequest, 100)

--- a/framework/data_request.go
+++ b/framework/data_request.go
@@ -43,7 +43,7 @@ func (f *framework) GetTaskData(taskID, epoch uint64, req string) ([]byte, error
 			return nil, frameworkhttp.ErrReqEpochMismatch
 		}
 		return d, nil
-	case <-f.closedSignal:
+	case <-f.httpStop:
 		// If a node stopped running and there is remaining requests, we need to
 		// respond error message back. It is used to let clients routine run through.
 		// In some tests it will call framework stop() to simulate failure of nodes.
@@ -69,7 +69,7 @@ func (f *framework) startHTTP() {
 // Close listener, stop HTTP server;
 // Write error message back to under-serving responses.
 func (f *framework) stopHTTP() {
-
+	close(f.httpStop)
 }
 
 func (f *framework) sendResponse(dr *dataResponse) {

--- a/framework/data_request.go
+++ b/framework/data_request.go
@@ -45,9 +45,10 @@ func (f *framework) GetTaskData(taskID, epoch uint64, req string) ([]byte, error
 		return d, nil
 	case <-f.httpStop:
 		// If a node stopped running and there is remaining requests, we need to
-		// respond error message back. It is used to let clients routine run through.
-		// In some tests it will call framework stop() to simulate failure of nodes.
-		// Notifying HTTP clients will be useful in those cases.
+		// respond error message back. It is used to let client routines stop blocking --
+		// especially helpful in test cases.
+
+		// This is used to drain the channel queue and get the rest notified.
 		<-f.dataReqChan
 		return nil, frameworkhttp.ErrServerClosed
 	}

--- a/framework/event_type.go
+++ b/framework/event_type.go
@@ -14,7 +14,7 @@ type dataRequest struct {
 	dataChan chan []byte
 }
 
-func (dr *dataRequest) EpochMismatch() {
+func (dr *dataRequest) notifyEpochMismatch() {
 	close(dr.dataChan)
 }
 
@@ -26,6 +26,6 @@ type dataResponse struct {
 	dataChan chan []byte
 }
 
-func (dr *dataResponse) EpochMismatch() {
+func (dr *dataResponse) notifyEpochMismatch() {
 	close(dr.dataChan)
 }

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -34,7 +34,7 @@ type framework struct {
 	metaStops []chan bool
 	epochStop chan bool
 
-	closedSignal  chan struct{}
+	httpStop      chan struct{}
 	heartbeatStop chan struct{}
 
 	// event loop

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -31,9 +31,10 @@ type framework struct {
 	ln         net.Listener
 
 	// etcd stops
-	stops     []chan bool
+	metaStops []chan bool
 	epochStop chan bool
 
+	closedSignal  chan struct{}
 	heartbeatStop chan struct{}
 
 	// event loop

--- a/framework/regression_framework.go
+++ b/framework/regression_framework.go
@@ -254,9 +254,12 @@ func (t *dummySlave) ChildDataReady(childID uint64, req string, resp []byte) {
 			t.gradient.Value += g.Value
 		}
 
+		// probably fail here
 		t.framework.FlagMetaToParent("GradientReady")
+		// probably fail here
 	}
 }
+
 func (t *dummySlave) testablyFail(method string, args ...string) bool {
 	if t.config == nil {
 		return false

--- a/framework/regression_framework.go
+++ b/framework/regression_framework.go
@@ -106,6 +106,9 @@ func (t *dummyMaster) ChildDataReady(childID uint64, req string, resp []byte) {
 		t.taskID, t.epoch, childID, len(t.fromChildren))
 	d := new(dummyData)
 	json.Unmarshal(resp, d)
+	if _, ok := t.fromChildren[childID]; ok {
+		return
+	}
 	t.fromChildren[childID] = d
 
 	// This is a weak form of checking. We can also check the task ids.
@@ -242,9 +245,12 @@ func (t *dummySlave) ParentDataReady(parentID uint64, req string, resp []byte) {
 
 func (t *dummySlave) ChildDataReady(childID uint64, req string, resp []byte) {
 	t.logger.Printf("slave ChildDataReady, task: %d, epoch: %d, child: %d\n", t.taskID, t.epoch, childID)
-	t.fromChildren[childID] = new(dummyData)
-	json.Unmarshal(resp, t.fromChildren[childID])
-
+	d := new(dummyData)
+	json.Unmarshal(resp, d)
+	if _, ok := t.fromChildren[childID]; ok {
+		return
+	}
+	t.fromChildren[childID] = d
 	// This is a weak form of checking. We can also check the task ids.
 	// But this really means that we get all the events from children, we
 	// should go into the next epoch now.
@@ -254,9 +260,23 @@ func (t *dummySlave) ChildDataReady(childID uint64, req string, resp []byte) {
 			t.gradient.Value += g.Value
 		}
 
-		// probably fail here
+		// If this failure happens, a new node will redo computing again.
+		if t.testablyFail("ChildDataReady") {
+			return
+		}
+
 		t.framework.FlagMetaToParent("GradientReady")
-		// probably fail here
+
+		// if this failure happens, the parent could
+		// 1. not have the data yet. In such case, the parent could
+		//   1.1 not request the data before a new node restarts. This will cause
+		//       double requests since we provide at-least-once semantics.
+		//   1.2 request the data with a failed host (request should fail or be
+		//       responded with error message).
+		// 2. already get the data.
+		if t.testablyFail("ChildDataReady") {
+			return
+		}
 	}
 }
 
@@ -292,7 +312,8 @@ type SimpleTaskBuilder struct {
 	GDataChan    chan int32
 	FinishChan   chan struct{}
 	NodeProducer chan bool
-	Config       map[string]string
+	MasterConfig map[string]string
+	SlaveConfig  map[string]string
 }
 
 // This method is called once by framework implementation to get the
@@ -304,11 +325,11 @@ func (tc SimpleTaskBuilder) GetTask(taskID uint64) meritop.Task {
 			dataChan:     tc.GDataChan,
 			finishChan:   tc.FinishChan,
 			NodeProducer: tc.NodeProducer,
-			config:       tc.Config,
+			config:       tc.MasterConfig,
 		}
 	}
 	return &dummySlave{
 		NodeProducer: tc.NodeProducer,
-		config:       tc.Config,
+		config:       tc.SlaveConfig,
 	}
 }

--- a/integration/node_failure_test.go
+++ b/integration/node_failure_test.go
@@ -112,3 +112,9 @@ func TestSlaveParentDataReadyFailure(t *testing.T) {
 	close(taskBuilder.NodeProducer)
 	<-taskBuilder.FinishChan
 }
+
+// This test tests fault tolerance in slave ChildDataReady() if node fails before/after
+// sending data to parent node
+func TestSlaveChildDataReadyFailure(t *testing.T) {
+
+}

--- a/task_interface.go
+++ b/task_interface.go
@@ -15,16 +15,16 @@ type Task interface {
 	// This give the task an opportunity to cleanup and regroup.
 	SetEpoch(epoch uint64)
 
-	// Ideally, we should also have the following:
+	// NOTE: the meta/data ready notifications follow at-least-once fault
+	// tolerance semantics
 	ParentMetaReady(parentID uint64, meta string)
 	ChildMetaReady(childID uint64, meta string)
+	ParentDataReady(parentID uint64, req string, resp []byte)
+	ChildDataReady(childID uint64, req string, resp []byte)
 
 	// These are payload for application purpose.
 	ServeAsParent(fromID uint64, req string) []byte
 	ServeAsChild(fromID uint64, req string) []byte
-
-	ParentDataReady(parentID uint64, req string, resp []byte)
-	ChildDataReady(childID uint64, req string, resp []byte)
 }
 
 type UpdateLog interface {


### PR DESCRIPTION
Since #101 , we have a way to handle epoch difference in failover.

One way to simulate this is let slave failed after sending his data to parent node. This PR is to finish the tests and fix related bugs.

The following need to be fixed.
- [x] http get error in RequestData()
  - [x] http get could fail if it gets address of an failed node. A case: child flag "gradient ready", child fail, parent request before new node gets up. It just do logging of the failure because it's fault tolerant.
  - [x] server should respond error message to all hanging clients when stopping itself. A case: child flag "gradient ready", parent request, child fail.
- [x] shutdown http server when framework stops.
- [x] Slave ChildDataReady
```Go
		// If this failure happens, a new node will redo computing again.
		if t.testablyFail("ChildDataReady") {
			return
		}

		t.framework.FlagMetaToParent("GradientReady")

		// if this failure happens, the parent could
		// 1. not have the data yet. In such case, the parent could
		//   1.1 not request the data before a new node restarts. This will cause
		//       double requests since we provide at-least-once semantics.
		//   1.2 request the data with a failed host (request should fail or be
		//       responded with error message).
		// 2. already get the data.
		if t.testablyFail("ChildDataReady") {
			return
		}
```