### PR TITLE
Regression Framework: Wait on gradient data ready in ChildDataReady

### DIFF
--- a/framework/regression_framework.go
+++ b/framework/regression_framework.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"strconv"
+	"sync"
 
 	"github.com/go-distributed/meritop"
 )
@@ -168,10 +169,12 @@ type dummySlave struct {
 
 	param, gradient *dummyData
 	fromChildren    map[uint64]*dummyData
+	gradientReady   *countDownLatch
 }
 
 // This is useful to bring the task up to speed from scratch or if it recovers.
 func (t *dummySlave) Init(taskID uint64, framework meritop.Framework) {
+	t.gradientReady = newCountDownLatch()
 	t.taskID = taskID
 	t.framework = framework
 	t.logger = log.New(os.Stdout, "", log.Ldate|log.Ltime|log.Lshortfile)
@@ -197,6 +200,7 @@ func (t *dummySlave) SetEpoch(epoch uint64) {
 	t.logger.Printf("slave SetEpoch, task: %d, epoch: %d\n", t.taskID, epoch)
 	t.param = &dummyData{}
 	t.gradient = &dummyData{}
+	t.gradientReady.ResetCounter(1)
 
 	t.epoch = epoch
 	// Make sure we have a clean slate.
@@ -225,11 +229,14 @@ func (t *dummySlave) ParentDataReady(parentID uint64, req string, resp []byte) {
 	if t.testablyFail("ParentDataReady") {
 		return
 	}
+	if t.gradientReady.IsDone() {
+		return
+	}
 	t.param = new(dummyData)
 	json.Unmarshal(resp, t.param)
-
 	// We need to carry out local compuation.
 	t.gradient.Value = t.param.Value * int32(t.framework.GetTaskID())
+	t.gradientReady.Done()
 
 	// If this task has children, flag meta so that children can start pull
 	// parameter.
@@ -255,6 +262,9 @@ func (t *dummySlave) ChildDataReady(childID uint64, req string, resp []byte) {
 	// But this really means that we get all the events from children, we
 	// should go into the next epoch now.
 	if len(t.fromChildren) == len(t.framework.GetTopology().GetChildren(t.epoch)) {
+		// If a new node restart and find out both parent and child meta ready, it will
+		// simultaneously request both data. We need to wait until gradient data is there.
+		t.gradientReady.Wait()
 		// In real ML, we add the gradient first.
 		for _, g := range t.fromChildren {
 			t.gradient.Value += g.Value
@@ -332,4 +342,49 @@ func (tc SimpleTaskBuilder) GetTask(taskID uint64) meritop.Task {
 		NodeProducer: tc.NodeProducer,
 		config:       tc.SlaveConfig,
 	}
+}
+
+// I am writing this count down latch because sync.WaitGroup doesn't support
+// decrementing counter when it's 0.
+type countDownLatch struct {
+	sync.Mutex
+	cond    *sync.Cond
+	counter int
+}
+
+func newCountDownLatch() *countDownLatch {
+	c := new(countDownLatch)
+	c.cond = sync.NewCond(c)
+	return c
+}
+
+func (c *countDownLatch) ResetCounter(count int) {
+	c.counter = count
+}
+
+func (c *countDownLatch) IsDone() bool {
+	c.Lock()
+	defer c.Unlock()
+	return c.counter == 0
+}
+
+func (c *countDownLatch) Done() {
+	c.Lock()
+	defer c.Unlock()
+	if c.counter == 0 {
+		return
+	}
+	c.counter--
+	if c.counter == 0 {
+		c.cond.Broadcast()
+	}
+}
+
+func (c *countDownLatch) Wait() {
+	c.Lock()
+	defer c.Unlock()
+	if c.counter == 0 {
+		return
+	}
+	c.cond.Wait()
 }


### PR DESCRIPTION
This attempts to fix a race (introduced in #104 ) in regression framework which caused build failures.

The log showed:
```
2015/01/12 06:01:09 bootstrap.go:179: standby got failure at task 6
2015/01/12 06:01:09 bootstrap.go:63: task 6 starting at epoch 10
2015/01/12 06:01:09 bootstrap.go:90: framework of task 6 starts to run
2015/01/12 06:01:09 regression_framework.go:197: slave SetEpoch, task: 6, epoch: 10
2015/01/12 06:01:09 data_request.go:62: task 6 serving http on 127.0.0.1:53281
2015/01/12 06:01:09 regression_framework.go:186: slave ParentMetaReady, task: 6, epoch: 10
2015/01/12 06:01:09 regression_framework.go:191: slave ChildMetaReady, task: 6, epoch: 10
2015/01/12 06:01:09 regression_framework.go:191: slave ChildMetaReady, task: 6, epoch: 10
2015/01/12 06:01:09 regression_framework.go:247: slave ChildDataReady, task: 6, epoch: 10, child: 14
2015/01/12 06:01:09 regression_framework.go:247: slave ChildDataReady, task: 6, epoch: 10, child: 13
2015/01/12 06:01:09 regression_framework.go:224: slave ParentDataReady, task: 6, epoch: 10, parent: 2
```

It's because the newly started task (6 in the scenario) getting data simultaneously from both parents and children. The ordering should go like:

1. get gradient data (broadcast variable) from parent first
2. do local compute with gradient from parent and parameters from children.
3. send computed output (parameters) back to parent.

However, according to the log it reversed 1 and 2, which is out of order. I am fixing regression framework in the following way:
1. coordinate between gradient from parent and parameters from children.
2. If it already have parameter, it doesn't need to process again.