### PR TITLE
Run controller/task in single process

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -52,25 +52,19 @@ func (c *Controller) Stop() error {
 
 func (c *Controller) InitEtcdLayout() error {
 	// Initilize the job epoch to 0
-	etcdMustCreate(c.etcdclient, c.logger, etcdutil.EpochPath(c.name), "0", 0)
+	etcdutil.MustCreate(c.etcdclient, c.logger, etcdutil.EpochPath(c.name), "0", 0)
 
 	// initiate etcd data layout
 	// currently it creates as many unassigned tasks as task masters.
 	for i := uint64(0); i < c.numOfTasks; i++ {
 		key := etcdutil.FreeTaskPath(c.name, strconv.FormatUint(i, 10))
-		etcdMustCreate(c.etcdclient, c.logger, key, "", 0)
+		etcdutil.MustCreate(c.etcdclient, c.logger, key, "", 0)
 		key = etcdutil.ParentMetaPath(c.name, i)
-		etcdMustCreate(c.etcdclient, c.logger, key, "", 0)
+		etcdutil.MustCreate(c.etcdclient, c.logger, key, "", 0)
 		key = etcdutil.ChildMetaPath(c.name, i)
-		etcdMustCreate(c.etcdclient, c.logger, key, "", 0)
+		etcdutil.MustCreate(c.etcdclient, c.logger, key, "", 0)
 	}
 	return nil
-}
-
-func etcdMustCreate(c *etcd.Client, logger *log.Logger, key, value string, ttl uint64) {
-	if _, err := c.Create(key, value, ttl); err != nil {
-		logger.Panicf("controller create failed. Key: %s, err: %v", key, err)
-	}
 }
 
 func (c *Controller) DestroyEtcdLayout() error {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -38,15 +38,15 @@ func TestControllerInitEtcdLayout(t *testing.T) {
 		for taskID := uint64(0); taskID < tt.numberOfTasks; taskID++ {
 			key := etcdutil.FreeTaskPath(c.name, strconv.FormatUint(taskID, 10))
 			if _, err := etcdClient.Get(key, false, false); err != nil {
-				t.Errorf("task %d: etcdClient.Get failed: %v", i, err)
+				t.Errorf("task %d: etcdClient.Get %v failed: %v", i, key, err)
 			}
 			key = etcdutil.ParentMetaPath(c.name, taskID)
 			if _, err := etcdClient.Get(key, false, false); err != nil {
-				t.Errorf("task %d: etcdClient.Get failed: %v", i, err)
+				t.Errorf("task %d: etcdClient.Get %v failed: %v", i, key, err)
 			}
 			key = etcdutil.ChildMetaPath(c.name, taskID)
 			if _, err := etcdClient.Get(key, false, false); err != nil {
-				t.Errorf("task %d: etcdClient.Get failed: %v", i, err)
+				t.Errorf("task %d: etcdClient.Get %v failed: %v", i, key, err)
 			}
 		}
 

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -37,9 +37,16 @@ func TestControllerInitEtcdLayout(t *testing.T) {
 
 		for taskID := uint64(0); taskID < tt.numberOfTasks; taskID++ {
 			key := etcdutil.FreeTaskPath(c.name, strconv.FormatUint(taskID, 10))
-			_, err := etcdClient.Get(key, false, false)
-			if err != nil {
-				t.Errorf("#%d: etcdClient.Get failed: %v", i, err)
+			if _, err := etcdClient.Get(key, false, false); err != nil {
+				t.Errorf("task %d: etcdClient.Get failed: %v", i, err)
+			}
+			key = etcdutil.ParentMetaPath(c.name, taskID)
+			if _, err := etcdClient.Get(key, false, false); err != nil {
+				t.Errorf("task %d: etcdClient.Get failed: %v", i, err)
+			}
+			key = etcdutil.ChildMetaPath(c.name, taskID)
+			if _, err := etcdClient.Get(key, false, false); err != nil {
+				t.Errorf("task %d: etcdClient.Get failed: %v", i, err)
 			}
 		}
 

--- a/example/regression/.gitignore
+++ b/example/regression/.gitignore
@@ -1,0 +1,2 @@
+regression
+result.txt

--- a/example/regression/README.md
+++ b/example/regression/README.md
@@ -24,16 +24,12 @@ The example assumes the default port 4001
 
 ### Start controller
 
+Modify `run_controller.sh` file with the correct `ETCDBIN` setting. Then run
+
 ```
 ./run_controller.sh
 ```
 
-### Start task
-
-```
-./run_regression.sh
-```
-Do it in two terminals. Because by default there are two tasks.
-
 ### Clean up
-No clean up needed.
+A binary: `regression`.
+An output file: `result.txt`.

--- a/example/regression/README.md
+++ b/example/regression/README.md
@@ -1,0 +1,39 @@
+Regression Framework
+======
+
+How to run
+------
+
+### Build
+```
+go build
+```
+This should generate a binary call `regression`.
+
+### Start etcd server
+
+Download an etcd binary from:
+https://github.com/coreos/etcd/releases
+
+Unzip, start it by doing
+```
+./etcd
+```
+
+The example assumes the default port 4001
+
+### Start controller
+
+```
+./run_controller.sh
+```
+
+### Start task
+
+```
+./run_regression.sh
+```
+Do it in two terminals. Because by default there are two tasks.
+
+### Clean up
+No clean up needed.

--- a/example/regression/README.md
+++ b/example/regression/README.md
@@ -22,14 +22,14 @@ Unzip, start it by doing
 
 The example assumes the default port 4001
 
-### Start controller
+### Run regression framework
 
-Modify `run_controller.sh` file with the correct `ETCDBIN` setting. Then run
+Modify `run_regression.sh` file with the correct `ETCDBIN` setting. Then run
 
 ```
-./run_controller.sh
+./run_regression.sh
 ```
 
 ### Clean up
-A binary: `regression`.
-An output file: `result.txt`.
+A binary: `regression`;
+An output file: `result.txt`;

--- a/example/regression/main.go
+++ b/example/regression/main.go
@@ -38,17 +38,9 @@ func main() {
 			FinishChan:         make(chan struct{}),
 			NumberOfIterations: 10,
 		}
-		go func() {
-			bootstrap.SetTaskBuilder(taskBuilder)
-			bootstrap.SetTopology(example.NewTreeTopology(2, ntask))
-			bootstrap.Start()
-		}()
-		data := make([]int32, 11)
-		for i := uint64(0); i <= taskBuilder.NumberOfIterations; i++ {
-			data[i] = <-taskBuilder.GDataChan
-		}
-		<-taskBuilder.FinishChan
-		log.Printf("data: %v", data)
+		bootstrap.SetTaskBuilder(taskBuilder)
+		bootstrap.SetTopology(example.NewTreeTopology(2, ntask))
+		bootstrap.Start()
 	default:
 		log.Fatal("Please choose a type: (c) controller, (t) task")
 	}

--- a/example/regression/main.go
+++ b/example/regression/main.go
@@ -39,6 +39,7 @@ func main() {
 			}()
 		}
 		wg.Wait()
+		log.Printf("Result has been written to 'result.txt'")
 	case "t":
 		log.Printf("task")
 		bootstrap := framework.NewBootStrap(*job, etcdURLs, createListener(), nil)

--- a/example/regression/main.go
+++ b/example/regression/main.go
@@ -4,8 +4,6 @@ import (
 	"flag"
 	"log"
 	"net"
-	"os/exec"
-	"sync"
 
 	"github.com/coreos/go-etcd/etcd"
 	"github.com/go-distributed/meritop/controller"
@@ -29,17 +27,7 @@ func main() {
 		log.Printf("controller")
 		controller := controller.New(*job, etcd.NewClient(etcdURLs), ntask)
 		controller.Start()
-
-		var wg sync.WaitGroup
-		wg.Add(2)
-		for i := 0; i < 2; i++ {
-			go func() {
-				exec.Command("./run_regression.sh").Run()
-				wg.Done()
-			}()
-		}
-		wg.Wait()
-		log.Printf("Result has been written to 'result.txt'")
+		controller.WaitForJobDone()
 	case "t":
 		log.Printf("task")
 		bootstrap := framework.NewBootStrap(*job, etcdURLs, createListener(), nil)

--- a/example/regression/main.go
+++ b/example/regression/main.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net"
+
+	"github.com/coreos/go-etcd/etcd"
+	"github.com/go-distributed/meritop/controller"
+	"github.com/go-distributed/meritop/example"
+	"github.com/go-distributed/meritop/framework"
+)
+
+func main() {
+	programType := flag.String("type", "", "(c) controller or (t) task")
+	job := flag.String("job", "", "job name")
+	etcdURLs := []string{"http://localhost:4001"}
+	flag.Parse()
+
+	if *job == "" {
+		log.Fatalf("Please specify a job name")
+	}
+
+	ntask := uint64(2)
+	switch *programType {
+	case "c":
+		log.Printf("controller")
+		controller := controller.New(*job, etcd.NewClient(etcdURLs), ntask)
+		controller.Start()
+		pause := make(chan struct{})
+		<-pause
+		//currently only manually ctrl+c is supported
+	case "t":
+		log.Printf("task")
+		bootstrap := framework.NewBootStrap(*job, etcdURLs, createListener(), nil)
+		taskBuilder := &framework.SimpleTaskBuilder{
+			GDataChan:          make(chan int32, 11),
+			FinishChan:         make(chan struct{}),
+			NumberOfIterations: 10,
+		}
+		go func() {
+			bootstrap.SetTaskBuilder(taskBuilder)
+			bootstrap.SetTopology(example.NewTreeTopology(2, ntask))
+			bootstrap.Start()
+		}()
+		data := make([]int32, 11)
+		for i := uint64(0); i <= taskBuilder.NumberOfIterations; i++ {
+			data[i] = <-taskBuilder.GDataChan
+		}
+		<-taskBuilder.FinishChan
+		log.Printf("data: %v", data)
+	default:
+		log.Fatal("Please choose a type: (c) controller, (t) task")
+	}
+}
+
+func createListener() net.Listener {
+	l, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		log.Fatalf("net.Listen(\"tcp4\", \"\") failed: %v", err)
+	}
+	return l
+}

--- a/example/regression/run_controller.sh
+++ b/example/regression/run_controller.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+ETCDBIN=$GOPATH/etcd-v2.0.0-darwin-amd64
+
+$ETCDBIN/etcdctl rm --recursive /
+
+./regression -job="haha" -type=c

--- a/example/regression/run_controller.sh
+++ b/example/regression/run_controller.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-ETCDBIN=$GOPATH/etcd-v2.0.0-darwin-amd64
-
-$ETCDBIN/etcdctl rm --recursive /
-
-./regression -job="regression test" -type=c

--- a/example/regression/run_controller.sh
+++ b/example/regression/run_controller.sh
@@ -4,4 +4,4 @@ ETCDBIN=$GOPATH/etcd-v2.0.0-darwin-amd64
 
 $ETCDBIN/etcdctl rm --recursive /
 
-./regression -job="haha" -type=c
+./regression -job="regression test" -type=c

--- a/example/regression/run_regression.sh
+++ b/example/regression/run_regression.sh
@@ -1,2 +1,25 @@
 #!/bin/sh
-./regression -job="regression test" -type=t
+
+ETCDBIN=$GOPATH/etcd-v2.0.0-darwin-amd64
+RESULT_FILE="result.txt"
+
+# clear etcd
+$ETCDBIN/etcdctl rm --recursive /
+rm $RESULT_FILE
+
+./regression -job="regression test" -type=c &
+
+# need to wait for controller to setup
+sleep 1
+./regression -job="regression test" -type=t &
+./regression -job="regression test" -type=t &
+
+while [ ! -e $RESULT_FILE ]; do
+    sleep 1
+done
+
+echo "Result has been written to file 'result.txt'. Reading the file:"
+echo "===== RESULT ====="
+cat $RESULT_FILE
+
+trap "kill 0" SIGINT SIGTERM EXIT

--- a/example/regression/run_regression.sh
+++ b/example/regression/run_regression.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+./regression -job="haha" -type=t

--- a/example/regression/run_regression.sh
+++ b/example/regression/run_regression.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-./regression -job="haha" -type=t
+./regression -job="regression test" -type=t

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -97,7 +97,9 @@ func (f *framework) stop() {
 // When node call this on framework, it simply set epoch to exitEpoch,
 // All nodes will be notified of the epoch change and exit themselves.
 func (f *framework) ShutdownJob() {
-	etcdutil.CASEpoch(f.etcdClient, f.name, f.epoch, exitEpoch)
+	if err := etcdutil.CASEpoch(f.etcdClient, f.name, f.epoch, exitEpoch); err != nil {
+		panic("TODO: we should do a set instead of CAS here.")
+	}
 }
 
 func (f *framework) GetLogger() *log.Logger { return f.log }

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -100,6 +100,9 @@ func (f *framework) ShutdownJob() {
 	if err := etcdutil.CASEpoch(f.etcdClient, f.name, f.epoch, exitEpoch); err != nil {
 		panic("TODO: we should do a set instead of CAS here.")
 	}
+	if err := etcdutil.SetJobStatus(f.etcdClient, f.name, 0); err != nil {
+		panic("SetJobStatus")
+	}
 }
 
 func (f *framework) GetLogger() *log.Logger { return f.log }

--- a/framework/regression_framework.go
+++ b/framework/regression_framework.go
@@ -124,7 +124,7 @@ func (t *dummyMaster) ChildDataReady(ctx meritop.Context, childID uint64, req st
 		// In real ML, we modify the gradient first. But here it is noop.
 		// Notice that we only
 		if t.epoch == t.numberOfIterations {
-			t.logger.Printf("Finished job. Shutting down...")
+			t.logger.Printf("Finished job. Gradient value: %v", t.gradient.Value)
 			t.framework.ShutdownJob()
 			close(t.finishChan)
 		} else {

--- a/framework/regression_framework.go
+++ b/framework/regression_framework.go
@@ -2,6 +2,8 @@ package framework
 
 import (
 	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -122,9 +124,11 @@ func (t *dummyMaster) ChildDataReady(ctx meritop.Context, childID uint64, req st
 		// TODO(xiaoyunwu) We need to do some test here.
 
 		// In real ML, we modify the gradient first. But here it is noop.
-		// Notice that we only
 		if t.epoch == t.numberOfIterations {
-			t.logger.Printf("Finished job. Gradient value: %v", t.gradient.Value)
+			if t.config["writefile"] != "" {
+				data := []byte(fmt.Sprintf("Finished job. Gradient value: %v\n", t.gradient.Value))
+				ioutil.WriteFile(t.config["writefile"], data, 0644)
+			}
 			t.framework.ShutdownJob()
 			close(t.finishChan)
 		} else {

--- a/framework_interface.go
+++ b/framework_interface.go
@@ -31,6 +31,7 @@ type Framework interface {
 
 	// Some task can inform all participating tasks to shutdown.
 	// If successful, all tasks will be gracefully shutdown.
+	// TODO: @param status
 	ShutdownJob()
 
 	GetLogger() *log.Logger

--- a/integration/regression_framework_test.go
+++ b/integration/regression_framework_test.go
@@ -22,6 +22,7 @@ func TestRegressionFramework(t *testing.T) {
 	job := "framework_regression_test"
 	etcds := []string{url}
 	numOfTasks := uint64(15)
+	numOfIterations := uint64(10)
 
 	// controller start first to setup task directories in etcd
 	controller := controller.New(job, etcd.NewClient([]string{url}), numOfTasks)
@@ -30,17 +31,17 @@ func TestRegressionFramework(t *testing.T) {
 
 	// We need to set etcd so that nodes know what to do.
 	taskBuilder := &framework.SimpleTaskBuilder{
-		GDataChan:  make(chan int32, 11),
-		FinishChan: make(chan struct{}),
+		GDataChan:          make(chan int32, 11),
+		FinishChan:         make(chan struct{}),
+		NumberOfIterations: numOfIterations,
 	}
 	for i := uint64(0); i < numOfTasks; i++ {
 		go drive(t, job, etcds, numOfTasks, taskBuilder)
 	}
 
-	// wait for last number to comeback.
 	wantData := []int32{0, 105, 210, 315, 420, 525, 630, 735, 840, 945, 1050}
-	getData := make([]int32, framework.NumOfIterations+1)
-	for i := uint64(0); i <= framework.NumOfIterations; i++ {
+	getData := make([]int32, numOfIterations+1)
+	for i := uint64(0); i <= numOfIterations; i++ {
 		getData[i] = <-taskBuilder.GDataChan
 	}
 	for i := range wantData {

--- a/pkg/etcdutil/healthy.go
+++ b/pkg/etcdutil/healthy.go
@@ -63,7 +63,7 @@ func WaitFreeTask(client *etcd.Client, name string, logger *log.Logger) (uint64,
 		if err != nil {
 			return 0, err
 		}
-		logger.Printf("got failures %v at index %d, randomly choose %d to try...", ListKeys(slots.Node.Nodes), slots.EtcdIndex, ri)
+		logger.Printf("got free task %v at index %d, randomly choose %d to try...", ListKeys(slots.Node.Nodes), slots.EtcdIndex, ri)
 		return id, nil
 	}
 

--- a/pkg/etcdutil/layout.go
+++ b/pkg/etcdutil/layout.go
@@ -24,6 +24,7 @@ const (
 	ConfigDir      = "config"
 	FreeDir        = "freeTasks"
 	Epoch          = "epoch"
+	Status         = "status"
 	TaskMaster     = "0"
 	TaskParentMeta = "parentMeta"
 	TaskChildMeta  = "childMeta"
@@ -34,6 +35,10 @@ const (
 
 func EpochPath(appName string) string {
 	return path.Join("/", appName, Epoch)
+}
+
+func JobStatusPath(appName string) string {
+	return path.Join("/", appName, Status)
 }
 
 func HealthyPath(appName string) string {

--- a/pkg/etcdutil/meta.go
+++ b/pkg/etcdutil/meta.go
@@ -1,0 +1,22 @@
+package etcdutil
+
+import "github.com/coreos/go-etcd/etcd"
+
+func WatchMeta(c *etcd.Client, taskID uint64, path string, stop chan bool, responseHandler func(*etcd.Response, uint64)) error {
+	resp, err := c.Get(path, false, false)
+	if err != nil {
+		return err
+	}
+	// Get previous meta. We need to handle it.
+	if resp.Node.Value != "" {
+		responseHandler(resp, taskID)
+	}
+	receiver := make(chan *etcd.Response, 1)
+	go c.Watch(path, resp.EtcdIndex+1, false, receiver, stop)
+	go func(receiver chan *etcd.Response) {
+		for resp := range receiver {
+			responseHandler(resp, taskID)
+		}
+	}(receiver)
+	return nil
+}

--- a/pkg/etcdutil/task.go
+++ b/pkg/etcdutil/task.go
@@ -32,3 +32,8 @@ func GetAddress(client *etcd.Client, name string, id uint64) (string, error) {
 	}
 	return resp.Node.Value, nil
 }
+
+func SetJobStatus(client *etcd.Client, name string, status int) error {
+	_, err := client.Set(JobStatusPath(name), "done", 0)
+	return err
+}

--- a/pkg/etcdutil/util.go
+++ b/pkg/etcdutil/util.go
@@ -1,17 +1,6 @@
 package etcdutil
 
-import (
-	"strings"
-
-	"github.com/coreos/go-etcd/etcd"
-)
-
-func IsKeyNotFound(err error) bool {
-	if strings.Contains(err.Error(), "Key not found") {
-		return true
-	}
-	return false
-}
+import "github.com/coreos/go-etcd/etcd"
 
 func ListKeys(nodes []*etcd.Node) []string {
 	res := make([]string, len(nodes))

--- a/pkg/etcdutil/util.go
+++ b/pkg/etcdutil/util.go
@@ -1,6 +1,10 @@
 package etcdutil
 
-import "github.com/coreos/go-etcd/etcd"
+import (
+	"log"
+
+	"github.com/coreos/go-etcd/etcd"
+)
 
 func ListKeys(nodes []*etcd.Node) []string {
 	res := make([]string, len(nodes))
@@ -8,4 +12,10 @@ func ListKeys(nodes []*etcd.Node) []string {
 		res[i] = n.Key
 	}
 	return res
+}
+
+func MustCreate(c *etcd.Client, logger *log.Logger, key, value string, ttl uint64) {
+	if _, err := c.Create(key, value, ttl); err != nil {
+		logger.Panicf("controller create failed. Key: %s, err: %v", key, err)
+	}
 }

--- a/pkg/etcdutil/util.go
+++ b/pkg/etcdutil/util.go
@@ -14,8 +14,10 @@ func ListKeys(nodes []*etcd.Node) []string {
 	return res
 }
 
-func MustCreate(c *etcd.Client, logger *log.Logger, key, value string, ttl uint64) {
-	if _, err := c.Create(key, value, ttl); err != nil {
+func MustCreate(c *etcd.Client, logger *log.Logger, key, value string, ttl uint64) *etcd.Response {
+	resp, err := c.Create(key, value, ttl)
+	if err != nil {
 		logger.Panicf("controller create failed. Key: %s, err: %v", key, err)
 	}
+	return resp
 }


### PR DESCRIPTION
Goal:
1. Run regression task in single process
2. Controller code is included in the binary. And it should be started at first.

Change in framework:
1. Task meta path will be setup by controller. Task will get the meta if exists or watch from that EtcdIndex. This replaces the previously index 1, which is problematic in shared etcd cluster environment.
2. ShutdownJob sets /job/status in etcd

Newly added:
A regression example:
1. could be started as controller.
2. or regression (master and slave) task.

TODO:
- [x] Regression example should not block on any channel. It should just call Start() and then wait until finished.
- [x] Controller launches tasks
- [x] submit task outside controller
- [x] job status monitoring: controller should watch a node "/job/status". When the job is finished, task master should set it and controller will be notified (to do final clean up).
- [x] move `mustCreate` to etcdutil
